### PR TITLE
Busy-night mode (pause quiz per bar)

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -97,6 +97,10 @@ model BarSettings {
   introText     String?
   outroText     String?
   pricingPounds Decimal @default(12.0) @db.Decimal(10, 2)
+
+  // Busy-night mode (soft stop): pause guest questionnaire but keep staff dashboard live.
+  quizPaused    Boolean @default(false)
+
   contactName       String?
   contactEmail      String?
   contactPhone      String?

--- a/api/src/bars/bar-quiz.service.ts
+++ b/api/src/bars/bar-quiz.service.ts
@@ -62,6 +62,10 @@ export class BarQuizService {
       throw new NotFoundException('Bar not found');
     }
 
+    if (bar.settings.quizPaused) {
+      throw new NotFoundException('Quiz is paused');
+    }
+
     const theme = {
       ...DEFAULT_THEME,
       ...(bar.settings.theme as Record<string, string> | null | undefined),
@@ -101,6 +105,10 @@ export class BarQuizService {
 
     if (!bar || !bar.settings) {
       throw new NotFoundException('Bar not found');
+    }
+
+    if (bar.settings.quizPaused) {
+      throw new NotFoundException('Quiz is paused');
     }
 
     const session = await this.prisma.quizSession.create({

--- a/api/src/bars/bars.service.ts
+++ b/api/src/bars/bars.service.ts
@@ -30,6 +30,7 @@ export interface BarSettingsResponse {
   slug: string;
   introText: string | null;
   outroText: string | null;
+  quizPaused: boolean;
   theme: Record<string, string>;
   pricingPounds: number;
   contactName: string | null;
@@ -258,6 +259,7 @@ export class BarsService {
         theme: mergedTheme,
         introText: dto.introText ?? existingSettings?.introText ?? null,
         outroText: dto.outroText ?? existingSettings?.outroText ?? null,
+        quizPaused: dto.quizPaused ?? existingSettings?.quizPaused ?? false,
         pricingPounds:
           typeof dto.pricingPounds === 'number'
             ? new Prisma.Decimal(dto.pricingPounds)
@@ -279,6 +281,7 @@ export class BarsService {
         theme: mergedTheme,
         introText: dto.introText !== undefined ? dto.introText : undefined,
         outroText: dto.outroText !== undefined ? dto.outroText : undefined,
+        quizPaused: dto.quizPaused !== undefined ? dto.quizPaused : undefined,
         pricingPounds:
           typeof dto.pricingPounds === 'number'
             ? new Prisma.Decimal(dto.pricingPounds)
@@ -370,6 +373,7 @@ export class BarsService {
       slug: bar.slug,
       introText: bar.settings.introText ?? null,
       outroText: bar.settings.outroText ?? null,
+      quizPaused: bar.settings.quizPaused ?? false,
       theme,
       pricingPounds: safePricing,
       contactName: bar.settings.contactName ?? null,

--- a/api/src/bars/dto/update-bar-settings.dto.ts
+++ b/api/src/bars/dto/update-bar-settings.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsArray,
+  IsBoolean,
   IsEmail,
   IsNumber,
   IsObject,
@@ -16,6 +17,10 @@ export class UpdateBarSettingsDto {
   @IsOptional()
   @IsString()
   outroText?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  quizPaused?: boolean;
 
   @IsOptional()
   @IsObject()

--- a/api/src/quiz/quiz.service.ts
+++ b/api/src/quiz/quiz.service.ts
@@ -61,11 +61,21 @@ export class QuizService {
         slug,
         active: true,
       },
-      select: { id: true },
+      include: {
+        settings: {
+          select: {
+            quizPaused: true,
+          },
+        },
+      },
     });
 
     if (!bar) {
       throw new NotFoundException('Bar not found');
+    }
+
+    if (bar.settings?.quizPaused) {
+      throw new NotFoundException('Quiz is paused');
     }
 
     const session = await this.prisma.quizSession.create({
@@ -116,6 +126,10 @@ export class QuizService {
 
         if (!session) {
           throw new NotFoundException('Quiz session not found');
+        }
+
+        if (session.bar.settings?.quizPaused) {
+          throw new NotFoundException('Quiz is paused');
         }
 
         if (dto.answers?.length) {

--- a/web/app/admin/bars/bar-editor-client.tsx
+++ b/web/app/admin/bars/bar-editor-client.tsx
@@ -21,6 +21,7 @@ interface BarSettingsResponse {
   id: string;
   introText: string | null;
   outroText: string | null;
+  quizPaused: boolean;
   theme: Record<string, string>;
   pricingPounds: number;
   contactName: string | null;
@@ -127,6 +128,7 @@ export default function BarEditorClient({ barId }: BarEditorClientProps) {
     id: barId ?? '',
     introText: null,
     outroText: null,
+    quizPaused: false,
     pricingPounds: 12,
     theme: { ...DEFAULT_THEME },
     contactName: null,
@@ -219,6 +221,7 @@ export default function BarEditorClient({ barId }: BarEditorClientProps) {
           id: settingsResponse.id,
           introText: settingsResponse.introText,
           outroText: settingsResponse.outroText,
+          quizPaused: settingsResponse.quizPaused ?? false,
           pricingPounds: settingsResponse.pricingPounds,
           theme: mergedTheme,
           contactName: settingsResponse.contactName,
@@ -385,6 +388,7 @@ export default function BarEditorClient({ barId }: BarEditorClientProps) {
         const payload: Record<string, unknown> = {
           introText: settings.introText ?? null,
           outroText: settings.outroText ?? null,
+          quizPaused: settings.quizPaused,
           pricingPounds: parsedPrice,
           theme: settings.theme
         };
@@ -422,6 +426,7 @@ export default function BarEditorClient({ barId }: BarEditorClientProps) {
           id: response.id,
           introText: response.introText,
           outroText: response.outroText,
+          quizPaused: response.quizPaused ?? false,
           pricingPounds: response.pricingPounds,
           theme: mergedTheme,
           contactName: response.contactName,
@@ -451,7 +456,7 @@ export default function BarEditorClient({ barId }: BarEditorClientProps) {
         setIsSavingSettings(false);
       }
     },
-    [barId, isNew, pricingInput, session?.apiToken, settings.introText, settings.outroText, settings.theme, status]
+    [barId, isNew, pricingInput, session?.apiToken, settings.introText, settings.outroText, settings.theme, status, settings.quizPaused]
   );
 
   const renderTabs = (
@@ -629,6 +634,27 @@ export default function BarEditorClient({ barId }: BarEditorClientProps) {
                         className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
                       />
                     </label>
+
+                    <label className="flex items-center gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+                      <input
+                        type="checkbox"
+                        checked={settings.quizPaused}
+                        onChange={(event) =>
+                          setSettings((current) => ({
+                            ...current,
+                            quizPaused: event.target.checked
+                          }))
+                        }
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                      />
+                      <div>
+                        <div className="text-sm font-medium text-foreground">Busy-night mode (pause quiz)</div>
+                        <div className="text-xs text-muted-foreground">
+                          Stops new guest quiz sessions for this bar. Staff dashboard stays live.
+                        </div>
+                      </div>
+                    </label>
+
                     <label className="space-y-2">
                       <span className="text-sm font-medium text-foreground">Pricing (GBP)</span>
                       <input

--- a/web/app/b/[barSlug]/quiz/QuizFlowClient.tsx
+++ b/web/app/b/[barSlug]/quiz/QuizFlowClient.tsx
@@ -70,6 +70,10 @@ export default function QuizFlow({ barSlug, outroText }: QuizFlowProps) {
         });
 
         if (!response.ok) {
+          if (response.status === 404) {
+            setError('This bar is paused right now. Please speak to staff.');
+            return;
+          }
           throw new Error(`Failed to start quiz session: ${response.status}`);
         }
 

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -97,6 +97,10 @@ model BarSettings {
   introText     String?
   outroText     String?
   pricingPounds Decimal @default(12.0) @db.Decimal(10, 2)
+
+  // Busy-night mode (soft stop): pause guest questionnaire but keep staff dashboard live.
+  quizPaused    Boolean @default(false)
+
   contactName       String?
   contactEmail      String?
   contactPhone      String?


### PR DESCRIPTION
## User description
Adds per-bar busy-night mode that pauses guest quiz (no new sessions/submits) while keeping staff dashboard live.

Changes:
- BarSettings.quizPaused (default false)
- API blocks quiz endpoints when quizPaused=true (returns 404)
- Admin Bar Editor toggle: Busy-night mode (pause quiz)
- Guest quiz shows message when bar is paused

How to test:
1) Admin → Bars → edit bar → Settings → toggle Busy-night mode ON → Save
2) Visit /b/<barSlug>/quiz: should show paused message
3) Toggle OFF and confirm quiz works again
4) Staff dashboard should still load and existing orders still viewable

Notes: uses 404 to avoid leaking bar status publicly.