### PR TITLE
fix(payments): harden Stripe webhook reconciliation

### DIFF
--- a/api/src/orders/orders.service.ts
+++ b/api/src/orders/orders.service.ts
@@ -158,6 +158,14 @@ export class OrdersService {
             barId: String(order.barId),
             sessionId: String(order.sessionId),
           },
+          // Ensure the PaymentIntent also carries metadata so we can reconcile payment_intent webhooks.
+          payment_intent_data: {
+            metadata: {
+              orderId: String(order.id),
+              barId: String(order.barId),
+              sessionId: String(order.sessionId),
+            },
+          },
           line_items: [
             {
               quantity: 1,


### PR DESCRIPTION
## **User description**
## User description\nHardens Stripe webhook reconciliation so orders correctly transition to PAID/CONFIRMED even when metadata or event ordering is imperfect.\n\nChanges:\n- Centralise webhook event handling + fallback lookups\n- Improve idempotency/guard rails around payment_intent / checkout.session events\n\nHow to test\n1) Run API locally and trigger Stripe webhook events (or replay from dashboard)\n2) Verify order transitions to PAID/CONFIRMED when receiving payment_intent.succeeded and/or checkout.session.completed\n3) Verify duplicate/replayed events are idempotent\n\nNotes\n- No schema changes.


___

## **CodeAnt-AI Description**
Harden Stripe webhook reconciliation so orders reliably transition to PAID/CONFIRMED

### What Changed
- Checkout sessions now include the same order metadata on the underlying PaymentIntent so payment webhooks can be linked to orders
- Webhooks handler accepts both checkout session completions (including async success) and payment_intent.succeeded, with fallback lookup by Stripe session id when metadata is missing
- Orders only move to "paid" when Stripe reports payment cleared (paid or no_payment_required); duplicate/replayed events update or reuse existing payment records rather than creating duplicates
- If Stripe reports a different session id, the order's stored session id is synced so future webhooks can match

### Impact
`✅ Fewer stuck orders awaiting manual reconciliation`
`✅ Clearer, non-duplicated payment records for refunded/audited orders`
`✅ More reliable automatic order status updates after Stripe webhooks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved payment processing reliability by adding support for additional checkout events, reducing instances of orders getting stuck in pending status.
  * Enhanced fallback mechanisms to recover order information when payment metadata is unavailable.
  * Fixed status transitions to prevent orders from being incorrectly marked as paid multiple times.

* **New Features**
  * Extended payment reconciliation to handle edge cases with improved tracking of payment details and order status synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->